### PR TITLE
[fix]herokuappが立ち上がらなかったため、原因となるGemの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,8 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 # Countermeasure for errors caused by net-smtp being an external gem
 gem 'net-smtp'
+gem 'net-imap'
+gem 'net-pop'
 
 group :test do
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,14 @@ GEM
     mini_mime (1.1.2)
     minitest (5.16.2)
     msgpack (1.5.3)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.1)
@@ -277,6 +285,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    strscan (3.0.4)
     temple (0.8.2)
     thor (1.2.1)
     tilt (2.0.10)
@@ -327,6 +336,8 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   kaminari
   listen (~> 3.3)
+  net-imap
+  net-pop
   net-smtp
   pg (~> 1.1)
   pry-rails


### PR DESCRIPTION
参考にしたURL
https://www.ruby-lang.org/ja/news/2021/12/25/ruby-3-1-0-released/